### PR TITLE
Fix broken CSS links in HTML files

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <meta property="og:url" content="https://theapexresolution.com">
     
     <!-- CSS -->
-    <link rel="stylesheet" href="assets/css/main.css">
+    <link rel="stylesheet" href="assets/index-hv19Wq6n.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     

--- a/pages/about.html
+++ b/pages/about.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>About Carlos Boyd & Apex Resolution</title>
     <meta name="description" content="Learn about Carlos Boyd, IAAIC certified AI consultant, and Apex Resolution's mission to empower Kansas City businesses.">
-    <link rel="stylesheet" href="../assets/css/main.css">
+    <link rel="stylesheet" href="../assets/index-hv19Wq6n.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 </head>

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Contact Apex Resolution - Book Your Free Consultation</title>
     <meta name="description" content="Contact Apex Resolution to schedule your free AI consultation. Transform your Kansas City business with proven AI solutions.">
-    <link rel="stylesheet" href="../assets/css/main.css">
+    <link rel="stylesheet" href="../assets/index-hv19Wq6n.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 </head>

--- a/pages/services.html
+++ b/pages/services.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AI Services & Solutions - Apex Resolution</title>
     <meta name="description" content="Comprehensive AI solutions including Voice Bots, APEX System, and business coaching for Kansas City small businesses.">
-    <link rel="stylesheet" href="../assets/css/main.css">
+    <link rel="stylesheet" href="../assets/index-hv19Wq6n.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 </head>


### PR DESCRIPTION
The website was not displaying correctly because the HTML files were linking to a non-existent CSS file (assets/css/main.css). This was likely caused by a build process that generates a hashed CSS filename (assets/index-hv19Wq6n.css).

This change updates all HTML files to point to the correct, hashed CSS file, restoring the website's styles.